### PR TITLE
FIX: Local storage cleared when cart is emptied and totalQty property fixed on cart state

### DIFF
--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -18,7 +18,6 @@ class Cart extends React.Component {
 
   render() {
     let currentCart = this.props.activeCart.experiences
-    console.log('CURRENT CART---->', currentCart)
     if (!currentCart || currentCart.length < 1) {
       return <h1>Nothing in cart</h1>
     }

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -65,10 +65,13 @@ const cartReducer = (state = activeCart, action) => {
             experience: action.payload,
             quantity: 1
           })
-          newCart.totalQty -= 1
+          newCart.totalQty += 1
         }
       }
       localStorage.setItem('cart', JSON.stringify(newCart))
+      if (newCart.totalQty === 0) {
+        localStorage.clear()
+      }
       return newCart
 
     case REMOVE_FROM_CART:
@@ -85,7 +88,9 @@ const cartReducer = (state = activeCart, action) => {
         }
       }
       localStorage.setItem('cart', JSON.stringify(newCart))
-      // history.push('/cart')
+      if (newCart.totalQty === 0) {
+        localStorage.clear()
+      }
       return newCart
 
     case DELETE_ALL_FROM_CART:
@@ -94,8 +99,13 @@ const cartReducer = (state = activeCart, action) => {
         let removalIndex = state.experiences.findIndex(
           item => item.experience.id === action.payload.id
         )
+        let totalQtyDecrement = newCart.experiences[removalIndex].quantity
         newCart.experiences = state.experiences.slice()
         newCart.experiences.splice(removalIndex, 1)
+        newCart.totalQty -= totalQtyDecrement
+      }
+      if (newCart.totalQty === 0) {
+        localStorage.clear()
       }
       return newCart
 


### PR DESCRIPTION
Total quantity wasn't being adjusted when a unique item was totally deleted. Local storage is now cleared when a user has nothing in cart.
